### PR TITLE
fix: 이미지 리스트 업로드 및 업로드 경로 수정

### DIFF
--- a/src/main/java/com/tennisPartner/tennisP/common/util/ImageUtil.java
+++ b/src/main/java/com/tennisPartner/tennisP/common/util/ImageUtil.java
@@ -3,6 +3,10 @@ package com.tennisPartner.tennisP.common.util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+import com.tennisPartner.tennisP.common.Exception.CustomException;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,7 +20,12 @@ public class ImageUtil {
             throws IOException {
         if (!saveImage.isEmpty()) {
             if (getImageExt(saveImage) != null) {
-                String saveName = idx + "." + getImageExt(saveImage);
+                saveDir = Paths.get(saveDir, getYyyyMmDd()).toString();
+                createFolder(saveDir);
+
+                String seq = String.valueOf(getFileSequence(saveDir));
+
+                String saveName = seq + "_" + idx + "." + getImageExt(saveImage);
                 String savePath = Paths.get(saveDir, saveName).toString();
                 saveImage.transferTo(new File(savePath));
                 return savePath;
@@ -40,5 +49,29 @@ public class ImageUtil {
             }
         }
         return null;
+    }
+
+    public static void createFolder(String dirName) {
+        File dir = new File(dirName);
+        if (!dir.exists()) {
+            if (dir.mkdirs() == false) {
+                throw new CustomException("폴더 생성 중 오류 발생", 500);
+            }
+        }
+    }
+
+    public static String getYyyyMmDd() {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        Calendar cal = Calendar.getInstance();
+        String today = sdf.format(cal.getTime());
+
+        return today;
+    }
+
+    public static Integer getFileSequence(String dirName) {
+        File dir = new File(dirName);
+        File[] files = dir.listFiles();
+
+        return files.length;
     }
 }

--- a/src/main/java/com/tennisPartner/tennisP/user/service/UserServiceImpl.java
+++ b/src/main/java/com/tennisPartner/tennisP/user/service/UserServiceImpl.java
@@ -34,7 +34,7 @@ public class UserServiceImpl implements UserService{
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository tokenRepository;
-    @Value("${user.upload.path}")
+    @Value("${upload.path.user}")
     private String UPLOAD_PATH;
 
     @Override


### PR DESCRIPTION
properties 변수
upload.path.user
upload.path.board
upload.path.club-board

예시
upload.path.user= C:\\Users\\Public\\00. Ock\\99. 개인\\00. 공부\\02. 프로젝트\\01. 테니스 파트너\\projects\\TennisParther\\src\\main\\resources\\user
upload.path.board= C:\\Users\\Public\\00. Ock\\99. 개인\\00. 공부\\02. 프로젝트\\01. 테니스 파트너\\projects\\TennisParther\\src\\main\\resources\\board
upload.path.club-board= C:\\Users\\Public\\00. Ock\\99. 개인\\00. 공부\\02. 프로젝트\\01. 테니스 파트너\\projects\\TennisParther\\src\\main\\resources\\club-board

" <- 절대 이 문자 추가하면 안됨

#124